### PR TITLE
perf: Use index iterator without intermediary set

### DIFF
--- a/TermSet.js
+++ b/TermSet.js
@@ -70,7 +70,7 @@ class TermSet {
   }
 
   [Symbol.iterator] () {
-    return this.values()[Symbol.iterator]()
+    return this.index.values()
   }
 }
 


### PR DESCRIPTION
Noticed in https://github.com/iherman/rdfjs-c14n/pull/12#discussion_r1484451200